### PR TITLE
Fix missing semi-colon breaking __nvm_can_run.

### DIFF
--- a/__nvm_can_run.fish
+++ b/__nvm_can_run.fish
@@ -1,5 +1,5 @@
 function __nvm_can_run
-  if type -P $argv[1] > /dev/null 2>&1 or type -P node > /dev/null 2>&1
+  if type -P $argv[1] > /dev/null 2>&1; or type -P node > /dev/null 2>&1
     return
   else
     return 1


### PR DESCRIPTION
After upgrading fisherman/nvm, I wasn't able to use any node commands due to this error:

```
Fish nvm: 'npm' is currently not installed, try running npm i -g npm
```

It seems as though `__nvm_can_run` was broken recently (by a missing semicolon), and this was preventing fisherman/nvm from picking up any node commands.