### PR TITLE
Add scripts to symlink in PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,26 +44,19 @@ end
 ```
 
 Another common scenario is if you need to have the binary of the node available. For example if you are vim user, some plugins need access to the node binary.
-Since we only source nvm when we use one of the alias, you will probably get an error saying that node isn't available. A simple solution would be creating a binary manually and put it somewhere on your PATH.
+Since we only source nvm when we use one of the alias, you will probably get an error saying that node isn't available.
+We have provided an easy way to get around this.
 
-For example to create a binary for `node` we could create a file under `/usr/local/bin`
-
-```
-touch `/usr/local/bin/node`
-```
-
-Open that file on your editor and paste the following:
+Navigate to where `fisherman/nvm` is installed, for instance:
 
 ```
-#! /usr/bin/env fish
-
-__nvm_run "node" $argv
+cd ~/.config/fisherman/nvm
 ```
 
-Make that file executable:
+Run `./symlink-scripts` with a destination that is in your PATH, for instance:
 
 ```
-chmod +x /usr/local/bin/node
+./symlink-scripts /usr/local/bin
 ```
 
 Test it

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ nvm wrapper for fish-shell.
 
 With [fisherman]
 
-```
+```fish
 fisher nvm
 ```
 
@@ -37,7 +37,7 @@ One way to solve this is running `nvm use default`, or any of the alias before u
 
 Since that's far from great, especially if you depend a lot on these global packages you can easily create your own function inside `~/.config/fish/functions`, so for `gulp` would be something like this:
 
-```
+```fish
 function gulp -d -w gulp
   __nvm_run "gulp" $argv
 end
@@ -49,19 +49,19 @@ We have provided an easy way to get around this.
 
 Navigate to where `fisherman/nvm` is installed, for instance:
 
-```
+```fish
 cd ~/.config/fisherman/nvm
 ```
 
 Run `./symlink-scripts` with a destination that is in your PATH, for instance:
 
-```
+```fish
 ./symlink-scripts /usr/local/bin
 ```
 
 Test it
 
-```
+```fish
 which node
 ```
 

--- a/scripts/node
+++ b/scripts/node
@@ -1,0 +1,2 @@
+#!/usr/bin/env fish
+__nvm_run "node" $argv

--- a/scripts/npm
+++ b/scripts/npm
@@ -1,0 +1,2 @@
+#!/usr/bin/env fish
+__nvm_run "npm" $argv

--- a/scripts/npx
+++ b/scripts/npx
@@ -1,0 +1,2 @@
+#!/usr/bin/env fish
+__nvm_run "npx" $argv

--- a/scripts/nvm
+++ b/scripts/nvm
@@ -1,0 +1,2 @@
+#!/usr/bin/env fish
+__nvm_run "nvm" $argv

--- a/scripts/yarn
+++ b/scripts/yarn
@@ -1,0 +1,2 @@
+#!/usr/bin/env fish
+__nvm_run "yarn" $argv

--- a/symlink-scripts
+++ b/symlink-scripts
@@ -11,21 +11,26 @@ end
 
 set -l scriptPaths (command ls -1 (realpath (status --current-filename)"/../scripts")/*) # gets those scripts' absolute paths
 
-set -l destination $argv[1]
+set -l destination (echo $argv[1] | string replace -r '/$' '') # remove trailing slash for aesthetic reasons
 
 if not test -d $destination
-  echo "$destination is not a directory."
+  set_color red
+  echo "ERROR: $destination is not a directory." 1>&2
+  set_color normal
   exit 2
 end
 
 for scriptOriginalPath in $scriptPaths
   set -l scriptName (basename $scriptOriginalPath)
-  set -l symlinkFilepath (realpath "$destination/$scriptName")
-  echo "$symlinkFilepath -> $scriptOriginalPath"
+  set -l symlinkFilepath  "$destination/$scriptName"
+  set_color red # ln only prints stuff if it fails so we can set it red
   ln -s $scriptOriginalPath $symlinkFilepath
   if test $status -ne 0
-    set_color red
     echo "WARNING: failed to symlink $scriptName" 1>&2
+  else
     set_color normal
+    echo "$symlinkFilepath -> $scriptOriginalPath"
   end
 end
+
+set_color normal

--- a/symlink-scripts
+++ b/symlink-scripts
@@ -1,0 +1,31 @@
+#!/usr/bin/env fish
+
+if test (count $argv) -lt 1
+  echo "Please specify a directory to symlink into by using:
+> ./symlink-scripts <directory>
+
+For example:
+> ./symlink-scripts /usr/local/bin"
+  exit 1
+end
+
+set -l scriptPaths (command ls -1 (realpath (status --current-filename)"/../scripts")/*) # gets those scripts' absolute paths
+
+set -l destination $argv[1]
+
+if not test -d $destination
+  echo "$destination is not a directory."
+  exit 2
+end
+
+for scriptOriginalPath in $scriptPaths
+  set -l scriptName (basename $scriptOriginalPath)
+  set -l symlinkFilepath (realpath "$destination/$scriptName")
+  echo "$symlinkFilepath -> $scriptOriginalPath"
+  ln -s $scriptOriginalPath $symlinkFilepath
+  if test $status -ne 0
+    set_color red
+    echo "WARNING: failed to symlink $scriptName"
+    set_color normal
+  end
+end

--- a/symlink-scripts
+++ b/symlink-scripts
@@ -28,7 +28,7 @@ for scriptOriginalPath in $scriptPaths
   if test $status -ne 0
     echo "WARNING: failed to symlink $scriptName" 1>&2
   else
-    set_color normal
+    set_color green
     echo "$symlinkFilepath -> $scriptOriginalPath"
   end
 end

--- a/symlink-scripts
+++ b/symlink-scripts
@@ -25,7 +25,7 @@ for scriptOriginalPath in $scriptPaths
   ln -s $scriptOriginalPath $symlinkFilepath
   if test $status -ne 0
     set_color red
-    echo "WARNING: failed to symlink $scriptName"
+    echo "WARNING: failed to symlink $scriptName" 1>&2
     set_color normal
   end
 end


### PR DESCRIPTION
I added some scripts that automate adding scripts to the PATH. Previously a way to do this manually was adding a file like:

```fish
#!/usr/bin/env fish
__nvm_run "node" $argv
```

to the PATH. Here I have written all those scripts, and added `./symlink-scripts` to add them to the PATH automatically too.