### PR TITLE
Bugfixes on Helper functions

### DIFF
--- a/functions/nvm_alias_command.fish
+++ b/functions/nvm_alias_command.fish
@@ -1,6 +1,5 @@
 function nvm_alias_command -d "Create an alias command"
-  set -l outputPath (__nvm_alias_output)
-  set -l path (string replace nvm_alias.fish '' (status --current-filename))
+  set -l path (string replace nvm_alias_command.fish '' (status --current-filename))
   set -l aliases (command ls -1 (realpath $path))
 
   function __nvm_alias_output
@@ -29,9 +28,13 @@ function nvm_alias_command -d "Create an alias command"
     end
   end
 
+  set -l outputPath (__nvm_alias_output)
   if test (count $argv) -le 0
     for val in $aliases
-      if test "nvm.fish" != $val; and test "nvm_alias.fish" != $val
+      if test $val != "nvm.fish";
+        and test $val != "nvm_alias_command.fish";
+        and test $val != "nvm_alias_function.fish"
+
         set -l alias (string replace .fish '' $val)
         __create_alias_command "$outputPath/$alias" $alias
       end

--- a/functions/nvm_alias_function.fish
+++ b/functions/nvm_alias_function.fish
@@ -8,7 +8,7 @@ function nvm_alias_function -d "Create an alias function"
     else
       set -l line1 "function COMMAND -w COMMAND"
       set -l line2 "__nvm_run \"COMMAND\" \$argv"
-      echo (string replace COMMAND $argv[2] $line1) > $argv[1]
+      echo (string replace -a COMMAND $argv[2] $line1) > $argv[1]
       echo (string replace COMMAND $argv[2] $line2) >> $argv[1]
       echo "end" >> $argv[1]
       return 0


### PR DESCRIPTION
Fixed:
* alias function wasn't replacing all the `COMMAND` strings

**allias command**
* was accessing function before declaring it
* string replace was using the wrong name file
* added `nvm_alias_function` and `nvm_alias_command` to the ignore list
