### PR TITLE
Check bass exit status, if it's an error return it

### DIFF
--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -8,6 +8,12 @@ function nvm
   
   bass source $nvm_prefix/nvm.sh --no-use ';' nvm $argv
 
+  set bstatus $status
+
+  if test $bstatus -gt 0
+    return $bstatus
+  end
+
   if test (count $argv) -lt 1
     return 0
   end


### PR DESCRIPTION
This will fix a rare scenario, when theres a `.nvmrc` file with a version that it's not installed globally, creating a recursive call.

depends on https://github.com/edc/bass/pull/53
  