### PR TITLE
Ability to set NVM_DIR and nvm_preffix separately in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ If you have a custom `$NVM_DIR`, please add the following line to your `~/.confi
 set -gx NVM_DIR /path/to/nvm
 ```
 
+Also, if you have a custom installation path but still set `$NVM_DIR` to default path. For example this could happen if you install [NVM] using [brew], which would install nvm into: `/usr/local/Cellar/nvm/%nvm_version%/nvm.sh`
+
+If that is the case you add the following line to your `~/.config/fish/config.fish`, replacing the path accordingly:
+
+```fish
+set -gx nvm_prefix /path/to/nvm
+```
+
 ## Other
 
 Check out also **[fnm]** a pure fish node version manager with automatic version switching.
@@ -126,3 +134,4 @@ Check out also **[fnm]** a pure fish node version manager with automatic version
 [fisherman]: https://github.com/fisherman/fisherman
 [NVM]: https://github.com/creationix/nvm
 [fnm]: https://github.com/fisherman/fnm
+[brew]: https://brew.sh/

--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -4,7 +4,7 @@ function nvm
     return
   end
   set -q NVM_DIR; or set -gx NVM_DIR ~/.nvm
-  set -q nvm_prefix; or set -g nvm_prefix $NVM_DIR
+  set -q nvm_prefix; or set -gx nvm_prefix $NVM_DIR
   
   bass source $nvm_prefix/nvm.sh --no-use ';' nvm $argv
 

--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -4,7 +4,7 @@ function nvm
     return
   end
   set -q NVM_DIR; or set -gx NVM_DIR ~/.nvm
-  set -g nvm_prefix $NVM_DIR
+  set -q nvm_prefix; or set -g nvm_prefix $NVM_DIR
   
   bass source $nvm_prefix/nvm.sh --no-use ';' nvm $argv
 


### PR DESCRIPTION
Ability to set NVM_DIR and nvm_preffix separately in configuration

This is needed if you have installed NVM using a custom path but still using ~/.nvm as NVM_DIR. For example this is the case when using brew to install NVM on MacOS.

Brew would install NVM into /usr/local/Cellar/nvm/%nvm_version%/nvm.sh and  ask to set $NVM_DIR to ~/.nvm. Hence user is required to set nvm_prefix separately from NVM_DIR.